### PR TITLE
fixed monster search to handle queries properly

### DIFF
--- a/src/main/java/com/dnd/tools/encounterhelper/monster/model/Ability.java
+++ b/src/main/java/com/dnd/tools/encounterhelper/monster/model/Ability.java
@@ -1,5 +1,7 @@
 package com.dnd.tools.encounterhelper.monster.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -30,9 +32,11 @@ public class Ability {
   @OneToMany(fetch= FetchType.EAGER, cascade={CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
   @Cascade(org.hibernate.annotations.CascadeType.SAVE_UPDATE)
   @JoinColumn(name="ABILITY_ID")
+  @JsonManagedReference
   private List<Ability> subEntries;
 
   @ManyToOne(fetch=FetchType.EAGER)
   @JoinColumn(name="ABILITY_ID")
+  @JsonBackReference
   private Ability self;
 }


### PR DESCRIPTION
@TKDMaster12 I fixed the search to stop acting up.  I did notice a few issues:

The UI seems to be requesting for different ChallengeRatings from the API than the slider is showing.

The armour class search works, but it doesn't search for Monsters that have multiple armour class options. (I need to do some updates for this)