### PR TITLE
Search excluding other filters when name is supplied is now fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ Upcoming features:
 - Filter by alignment (need to add this if we do this)
 - Filter by types
 
-Filter examples: https://donjon.bin.sh/5e/monsters/
-
-Bugs:
-- if search for name other filters don't work
-
 Ian feedback Nice to Have:
 - Mark turn over option
 - Condition tracking feature

--- a/src/main/java/com/dnd/tools/encounterhelper/monster/CustomMonsterSearchRepositoryImpl.java
+++ b/src/main/java/com/dnd/tools/encounterhelper/monster/CustomMonsterSearchRepositoryImpl.java
@@ -26,7 +26,7 @@ public class CustomMonsterSearchRepositoryImpl implements CustomMonsterSearchRep
 
     if(partialName.length() > 0) {
       //Exact match
-      queryBuilder.append(" WHERE LOWER(m.NAME) = '");
+      queryBuilder.append(" WHERE (LOWER(m.NAME) = '");
       queryBuilder.append(partialName);
       queryBuilder.append("'");
 
@@ -43,7 +43,7 @@ public class CustomMonsterSearchRepositoryImpl implements CustomMonsterSearchRep
       //Match end of name
       queryBuilder.append(" OR LOWER(m.NAME) LIKE '");
       queryBuilder.append(partialName);
-      queryBuilder.append("%'");
+      queryBuilder.append("%')");
     }
 
     List<String> sizes = monsterSearch.getSizes();


### PR DESCRIPTION
@TKDMaster12 Bug fix for when the name is being used and the other filters weren't applied